### PR TITLE
챌린지 CRUD

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,6 +41,8 @@ dependencies {
 	compileOnly group: 'io.jsonwebtoken', name: 'jjwt-api', version: '0.11.5'
 	runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-impl', version: '0.11.5'
 	runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-jackson', version: '0.11.5'
+
+	testImplementation 'org.mockito:mockito-core:5.18.0'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/github/nenidan/ne_ne_challenge/domain/challenge/controller/ChallengeController.java
+++ b/src/main/java/com/github/nenidan/ne_ne_challenge/domain/challenge/controller/ChallengeController.java
@@ -1,18 +1,19 @@
 package com.github.nenidan.ne_ne_challenge.domain.challenge.controller;
 
+import com.github.nenidan.ne_ne_challenge.domain.challenge.dto.request.ChallengeSearchCond;
 import com.github.nenidan.ne_ne_challenge.domain.challenge.dto.request.CreateChallengeRequest;
 import com.github.nenidan.ne_ne_challenge.domain.challenge.dto.response.ChallengeResponse;
 import com.github.nenidan.ne_ne_challenge.domain.challenge.service.ChallengeService;
 import com.github.nenidan.ne_ne_challenge.global.dto.ApiResponse;
+import com.github.nenidan.ne_ne_challenge.global.dto.CursorResponse;
 import com.github.nenidan.ne_ne_challenge.global.security.auth.Auth;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDateTime;
 
 @RestController
 @RequestMapping("/api")
@@ -28,6 +29,22 @@ public class ChallengeController {
         return ApiResponse.success(HttpStatus.CREATED,
             "챌린지를 생성했습니다.",
             challengeService.createChallenge(request, auth.getId())
+        );
+    }
+
+    @GetMapping("/challenges/{id}")
+    public ResponseEntity<ApiResponse<ChallengeResponse>> getChallenge(@PathVariable Long id) {
+        return ApiResponse.success(HttpStatus.OK,
+            "챌린지를 조회했습니다.",
+            challengeService.getChallenge(id)
+        );
+    }
+
+    @GetMapping("/challenges")
+    public ResponseEntity<ApiResponse<CursorResponse<ChallengeResponse, LocalDateTime>>> getChallengeList(@ModelAttribute ChallengeSearchCond cond) {
+        return ApiResponse.success(HttpStatus.OK,
+            "챌린지 목록을 조회했습니다.",
+            challengeService.getChallengeList(cond)
         );
     }
 }

--- a/src/main/java/com/github/nenidan/ne_ne_challenge/domain/challenge/controller/ChallengeController.java
+++ b/src/main/java/com/github/nenidan/ne_ne_challenge/domain/challenge/controller/ChallengeController.java
@@ -2,6 +2,7 @@ package com.github.nenidan.ne_ne_challenge.domain.challenge.controller;
 
 import com.github.nenidan.ne_ne_challenge.domain.challenge.dto.request.ChallengeSearchCond;
 import com.github.nenidan.ne_ne_challenge.domain.challenge.dto.request.CreateChallengeRequest;
+import com.github.nenidan.ne_ne_challenge.domain.challenge.dto.request.UpdateChallengeRequest;
 import com.github.nenidan.ne_ne_challenge.domain.challenge.dto.response.ChallengeResponse;
 import com.github.nenidan.ne_ne_challenge.domain.challenge.service.ChallengeService;
 import com.github.nenidan.ne_ne_challenge.global.dto.ApiResponse;
@@ -23,12 +24,12 @@ public class ChallengeController {
     private final ChallengeService challengeService;
 
     @PostMapping("/challenges")
-    public ResponseEntity<ApiResponse<ChallengeResponse>> createChallenge(@AuthenticationPrincipal Auth auth,
+    public ResponseEntity<ApiResponse<ChallengeResponse>> createChallenge(@AuthenticationPrincipal Auth authUser,
         @RequestBody CreateChallengeRequest request
     ) {
         return ApiResponse.success(HttpStatus.CREATED,
             "챌린지를 생성했습니다.",
-            challengeService.createChallenge(request, auth.getId())
+            challengeService.createChallenge(request, authUser.getId())
         );
     }
 
@@ -45,6 +46,14 @@ public class ChallengeController {
         return ApiResponse.success(HttpStatus.OK,
             "챌린지 목록을 조회했습니다.",
             challengeService.getChallengeList(cond)
+        );
+    }
+
+    @PatchMapping("/challenges/{id}")
+    public ResponseEntity<ApiResponse<ChallengeResponse>> updateChallenge(@AuthenticationPrincipal Auth authUser, @RequestBody UpdateChallengeRequest request, @PathVariable Long id) {
+        return ApiResponse.success(HttpStatus.OK,
+            "챌린지 정보를 수정했습니다.",
+            challengeService.updateChallenge(authUser.getId(), id, request)
         );
     }
 }

--- a/src/main/java/com/github/nenidan/ne_ne_challenge/domain/challenge/controller/ChallengeController.java
+++ b/src/main/java/com/github/nenidan/ne_ne_challenge/domain/challenge/controller/ChallengeController.java
@@ -1,8 +1,16 @@
 package com.github.nenidan.ne_ne_challenge.domain.challenge.controller;
 
+import com.github.nenidan.ne_ne_challenge.domain.challenge.dto.request.CreateChallengeRequest;
+import com.github.nenidan.ne_ne_challenge.domain.challenge.dto.response.ChallengeResponse;
 import com.github.nenidan.ne_ne_challenge.domain.challenge.service.ChallengeService;
-import com.github.nenidan.ne_ne_challenge.domain.challenge.type.ChallengeStatus;
+import com.github.nenidan.ne_ne_challenge.global.dto.ApiResponse;
+import com.github.nenidan.ne_ne_challenge.global.security.auth.Auth;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -12,4 +20,14 @@ import org.springframework.web.bind.annotation.RestController;
 public class ChallengeController {
 
     private final ChallengeService challengeService;
+
+    @PostMapping("/challenges")
+    public ResponseEntity<ApiResponse<ChallengeResponse>> createChallenge(@AuthenticationPrincipal Auth auth,
+        @RequestBody CreateChallengeRequest request
+    ) {
+        return ApiResponse.success(HttpStatus.CREATED,
+            "챌린지를 생성했습니다.",
+            challengeService.createChallenge(request, auth.getId())
+        );
+    }
 }

--- a/src/main/java/com/github/nenidan/ne_ne_challenge/domain/challenge/controller/ChallengeController.java
+++ b/src/main/java/com/github/nenidan/ne_ne_challenge/domain/challenge/controller/ChallengeController.java
@@ -56,4 +56,12 @@ public class ChallengeController {
             challengeService.updateChallenge(authUser.getId(), id, request)
         );
     }
+
+    @DeleteMapping("/challenges/{id}")
+    public ResponseEntity<ApiResponse<Void>> deleteChallenge(@AuthenticationPrincipal Auth authUser, @PathVariable Long id) {
+        return ApiResponse.success(HttpStatus.OK,
+            "챌린지를 삭제했습니다.",
+            challengeService.deleteChallenge(authUser.getId(), id)
+        );
+    }
 }

--- a/src/main/java/com/github/nenidan/ne_ne_challenge/domain/challenge/controller/ChallengeController.java
+++ b/src/main/java/com/github/nenidan/ne_ne_challenge/domain/challenge/controller/ChallengeController.java
@@ -7,11 +7,9 @@ import com.github.nenidan.ne_ne_challenge.domain.challenge.dto.response.Challeng
 import com.github.nenidan.ne_ne_challenge.domain.challenge.service.ChallengeService;
 import com.github.nenidan.ne_ne_challenge.global.dto.ApiResponse;
 import com.github.nenidan.ne_ne_challenge.global.dto.CursorResponse;
-import com.github.nenidan.ne_ne_challenge.global.security.auth.Auth;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.time.LocalDateTime;
@@ -24,44 +22,29 @@ public class ChallengeController {
     private final ChallengeService challengeService;
 
     @PostMapping("/challenges")
-    public ResponseEntity<ApiResponse<ChallengeResponse>> createChallenge(@AuthenticationPrincipal Auth authUser,
-        @RequestBody CreateChallengeRequest request
-    ) {
-        return ApiResponse.success(HttpStatus.CREATED,
-            "챌린지를 생성했습니다.",
-            challengeService.createChallenge(request, authUser.getId())
-        );
+    public ResponseEntity<ApiResponse<ChallengeResponse>> createChallenge(@RequestBody CreateChallengeRequest request) {
+        return ApiResponse.success(HttpStatus.CREATED, "챌린지를 생성했습니다.", challengeService.createChallenge(request));
     }
 
     @GetMapping("/challenges/{id}")
     public ResponseEntity<ApiResponse<ChallengeResponse>> getChallenge(@PathVariable Long id) {
-        return ApiResponse.success(HttpStatus.OK,
-            "챌린지를 조회했습니다.",
-            challengeService.getChallenge(id)
-        );
+        return ApiResponse.success(HttpStatus.OK, "챌린지를 조회했습니다.", challengeService.getChallenge(id));
     }
 
     @GetMapping("/challenges")
     public ResponseEntity<ApiResponse<CursorResponse<ChallengeResponse, LocalDateTime>>> getChallengeList(@ModelAttribute ChallengeSearchCond cond) {
-        return ApiResponse.success(HttpStatus.OK,
-            "챌린지 목록을 조회했습니다.",
-            challengeService.getChallengeList(cond)
-        );
+        return ApiResponse.success(HttpStatus.OK, "챌린지 목록을 조회했습니다.", challengeService.getChallengeList(cond));
     }
 
     @PatchMapping("/challenges/{id}")
-    public ResponseEntity<ApiResponse<ChallengeResponse>> updateChallenge(@AuthenticationPrincipal Auth authUser, @RequestBody UpdateChallengeRequest request, @PathVariable Long id) {
-        return ApiResponse.success(HttpStatus.OK,
-            "챌린지 정보를 수정했습니다.",
-            challengeService.updateChallenge(authUser.getId(), id, request)
-        );
+    public ResponseEntity<ApiResponse<ChallengeResponse>> updateChallenge(@RequestBody UpdateChallengeRequest request,
+        @PathVariable Long id
+    ) {
+        return ApiResponse.success(HttpStatus.OK, "챌린지 정보를 수정했습니다.", challengeService.updateChallenge(id, request));
     }
 
     @DeleteMapping("/challenges/{id}")
-    public ResponseEntity<ApiResponse<Void>> deleteChallenge(@AuthenticationPrincipal Auth authUser, @PathVariable Long id) {
-        return ApiResponse.success(HttpStatus.OK,
-            "챌린지를 삭제했습니다.",
-            challengeService.deleteChallenge(authUser.getId(), id)
-        );
+    public ResponseEntity<ApiResponse<Void>> deleteChallenge(@PathVariable Long id, @RequestParam Long userId) {
+        return ApiResponse.success(HttpStatus.OK, "챌린지를 삭제했습니다.", challengeService.deleteChallenge(userId, id));
     }
 }

--- a/src/main/java/com/github/nenidan/ne_ne_challenge/domain/challenge/dto/request/ChallengeSearchCond.java
+++ b/src/main/java/com/github/nenidan/ne_ne_challenge/domain/challenge/dto/request/ChallengeSearchCond.java
@@ -28,9 +28,4 @@ public class ChallengeSearchCond {
     private LocalDateTime cursor = LocalDateTime.of(9999, 12, 31, 23, 59, 59);
 
     private int size = 10;
-
-    @Override
-    public String toString() {
-        return "ChallengeSearchCond{" + "userId=" + userId + ", name='" + name + '\'' + ", status=" + status + ", dueAt=" + dueAt + ", category=" + category + ", maxParticipationFee=" + maxParticipationFee + ", cursor=" + cursor + ", size=" + size + '}';
-    }
 }

--- a/src/main/java/com/github/nenidan/ne_ne_challenge/domain/challenge/dto/request/ChallengeSearchCond.java
+++ b/src/main/java/com/github/nenidan/ne_ne_challenge/domain/challenge/dto/request/ChallengeSearchCond.java
@@ -1,0 +1,36 @@
+package com.github.nenidan.ne_ne_challenge.domain.challenge.dto.request;
+
+import com.github.nenidan.ne_ne_challenge.domain.challenge.type.ChallengeCategory;
+import com.github.nenidan.ne_ne_challenge.domain.challenge.type.ChallengeStatus;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+// Todo 빈 검증 제약 조건
+@Getter
+@Setter
+public class ChallengeSearchCond {
+
+    private Long userId;
+
+    private String name;
+
+    private ChallengeStatus status;
+
+    private LocalDate dueAt;
+
+    private ChallengeCategory category;
+
+    private Integer maxParticipationFee;
+
+    private LocalDateTime cursor = LocalDateTime.of(9999, 12, 31, 23, 59, 59);
+
+    private int size = 10;
+
+    @Override
+    public String toString() {
+        return "ChallengeSearchCond{" + "userId=" + userId + ", name='" + name + '\'' + ", status=" + status + ", dueAt=" + dueAt + ", category=" + category + ", maxParticipationFee=" + maxParticipationFee + ", cursor=" + cursor + ", size=" + size + '}';
+    }
+}

--- a/src/main/java/com/github/nenidan/ne_ne_challenge/domain/challenge/dto/request/CreateChallengeRequest.java
+++ b/src/main/java/com/github/nenidan/ne_ne_challenge/domain/challenge/dto/request/CreateChallengeRequest.java
@@ -10,6 +10,9 @@ import java.time.LocalDate;
 @Getter
 public class CreateChallengeRequest {
 
+    // 요청자 id
+    private Long userId;
+
     // Todo 빈 검증 제약조건
     private String name;
 

--- a/src/main/java/com/github/nenidan/ne_ne_challenge/domain/challenge/dto/request/CreateChallengeRequest.java
+++ b/src/main/java/com/github/nenidan/ne_ne_challenge/domain/challenge/dto/request/CreateChallengeRequest.java
@@ -1,0 +1,39 @@
+package com.github.nenidan.ne_ne_challenge.domain.challenge.dto.request;
+
+import com.github.nenidan.ne_ne_challenge.domain.challenge.entity.Challenge;
+import com.github.nenidan.ne_ne_challenge.domain.challenge.type.ChallengeCategory;
+import com.github.nenidan.ne_ne_challenge.domain.challenge.type.ChallengeStatus;
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+@Getter
+public class CreateChallengeRequest {
+
+    // Todo 빈 검증 제약조건
+    private String name;
+
+    private String description;
+
+    private int minParticipants;
+
+    private int maxParticipants;
+
+    private LocalDate dueAt;
+
+    private ChallengeCategory category;
+
+    private int participationFee;
+
+    public Challenge toEntity() {
+        return new Challenge(name,
+            description,
+            ChallengeStatus.WAITING,
+            category,
+            minParticipants,
+            maxParticipants,
+            participationFee,
+            dueAt
+        );
+    }
+}

--- a/src/main/java/com/github/nenidan/ne_ne_challenge/domain/challenge/dto/request/UpdateChallengeRequest.java
+++ b/src/main/java/com/github/nenidan/ne_ne_challenge/domain/challenge/dto/request/UpdateChallengeRequest.java
@@ -1,0 +1,25 @@
+package com.github.nenidan.ne_ne_challenge.domain.challenge.dto.request;
+
+import com.github.nenidan.ne_ne_challenge.domain.challenge.type.ChallengeCategory;
+import com.github.nenidan.ne_ne_challenge.domain.challenge.type.ChallengeStatus;
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+@Getter
+public class UpdateChallengeRequest {
+
+    private String name;
+
+    private String description;
+
+    private ChallengeStatus status;
+
+    private int minParticipants;
+
+    private int maxParticipants;
+
+    private LocalDate dueAt;
+
+    private ChallengeCategory category;
+}

--- a/src/main/java/com/github/nenidan/ne_ne_challenge/domain/challenge/dto/request/UpdateChallengeRequest.java
+++ b/src/main/java/com/github/nenidan/ne_ne_challenge/domain/challenge/dto/request/UpdateChallengeRequest.java
@@ -9,6 +9,9 @@ import java.time.LocalDate;
 @Getter
 public class UpdateChallengeRequest {
 
+    // 요청자의 userId
+    private Long userId;
+
     private String name;
 
     private String description;

--- a/src/main/java/com/github/nenidan/ne_ne_challenge/domain/challenge/dto/response/ChallengeResponse.java
+++ b/src/main/java/com/github/nenidan/ne_ne_challenge/domain/challenge/dto/response/ChallengeResponse.java
@@ -1,4 +1,56 @@
 package com.github.nenidan.ne_ne_challenge.domain.challenge.dto.response;
 
+import com.github.nenidan.ne_ne_challenge.domain.challenge.entity.Challenge;
+import com.github.nenidan.ne_ne_challenge.domain.challenge.type.ChallengeCategory;
+import com.github.nenidan.ne_ne_challenge.domain.challenge.type.ChallengeStatus;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class ChallengeResponse {
+
+    private Long id;
+
+    private String name;
+
+    private String description;
+
+    private ChallengeStatus status;
+
+    private int minParticipants;
+
+    private int maxParticipants;
+
+    private LocalDateTime createdAt;
+
+    private LocalDate dueAt;
+
+    private LocalDateTime startedAt;
+
+    private ChallengeCategory category;
+
+    private int participationFee;
+
+    private int totalFee;
+
+    public static ChallengeResponse from(Challenge challenge) {
+        return new ChallengeResponse(challenge.getId(),
+            challenge.getName(),
+            challenge.getDescription(),
+            challenge.getStatus(),
+            challenge.getMinParticipants(),
+            challenge.getMaxParticipants(),
+            challenge.getCreatedAt(),
+            challenge.getDueAt(),
+            challenge.getStartedAt(),
+            challenge.getCategory(),
+            challenge.getParticipationFee(),
+            challenge.getTotalFee()
+        );
+    }
 }

--- a/src/main/java/com/github/nenidan/ne_ne_challenge/domain/challenge/entity/Challenge.java
+++ b/src/main/java/com/github/nenidan/ne_ne_challenge/domain/challenge/entity/Challenge.java
@@ -1,5 +1,6 @@
 package com.github.nenidan.ne_ne_challenge.domain.challenge.entity;
 
+import com.github.nenidan.ne_ne_challenge.domain.challenge.exception.ChallengeException;
 import com.github.nenidan.ne_ne_challenge.domain.challenge.type.ChallengeCategory;
 import com.github.nenidan.ne_ne_challenge.domain.challenge.type.ChallengeStatus;
 import com.github.nenidan.ne_ne_challenge.domain.user.entity.User;
@@ -10,6 +11,10 @@ import lombok.NoArgsConstructor;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.chrono.ChronoLocalDate;
+
+import static com.github.nenidan.ne_ne_challenge.domain.challenge.exception.ChallengeErrorCode.*;
+import static com.github.nenidan.ne_ne_challenge.domain.challenge.type.ChallengeStatus.*;
 
 @Entity
 @Getter
@@ -64,5 +69,48 @@ public class Challenge extends BaseEntity {
     // Todo OneToMany로 participants를 받도록 리팩터링 → ChallengeUserService 불필요
     public void addParticipant(User user) {
         this.totalFee += this.participationFee;
+    }
+
+    // 항상 변경 가능한 속성
+    public void safeUpdate(String name, String description, ChallengeCategory category) {
+        if (name != null) this.name = name;
+        if (description != null) this.description = description;
+        if (category != null) this.category = category;
+    }
+
+    public void start(int currentParticipants) {
+        if (status != WAITING) throw new ChallengeException(INVALID_STATUS_TRANSITION);
+
+        if (currentParticipants < minParticipants || currentParticipants > maxParticipants) {
+            throw new ChallengeException(CHALLENGE_PARTICIPANT_LIMIT_EXCEEDED);
+        }
+
+        if (dueAt.isBefore(ChronoLocalDate.from(LocalDateTime.now()))) {
+            this.status = FINISHED;
+            throw new ChallengeException(CHALLENGE_ALREADY_FINISHED);
+        }
+
+        startedAt = LocalDateTime.now();
+        status = ONGOING;
+    }
+
+    public void setDueDate(LocalDate dueAt) {
+        if (status != WAITING) throw new ChallengeException(CHALLENGE_ALREADY_STARTED);
+        if (dueAt.isBefore(ChronoLocalDate.from(LocalDateTime.now()))) throw new ChallengeException(INVALID_DUE_DATE);
+
+        this.dueAt = dueAt;
+    }
+
+    public void updateParticipantsLimit(int currentParticipants, int minParticipants, int maxParticipants) {
+        if (status != WAITING) throw new ChallengeException(CHALLENGE_ALREADY_STARTED);
+        if (minParticipants > maxParticipants || currentParticipants > maxParticipants)
+            throw new ChallengeException(INVALID_PARTICIPANT_LIMIT);
+
+        this.minParticipants = minParticipants;
+        this.maxParticipants = maxParticipants;
+
+        if (this.minParticipants <= currentParticipants) {
+            start(currentParticipants);
+        }
     }
 }

--- a/src/main/java/com/github/nenidan/ne_ne_challenge/domain/challenge/entity/Challenge.java
+++ b/src/main/java/com/github/nenidan/ne_ne_challenge/domain/challenge/entity/Challenge.java
@@ -8,6 +8,7 @@ import com.github.nenidan.ne_ne_challenge.global.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLRestriction;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -19,6 +20,7 @@ import static com.github.nenidan.ne_ne_challenge.domain.challenge.type.Challenge
 @Entity
 @Getter
 @NoArgsConstructor
+@SQLRestriction("deleted_at IS NULL")
 public class Challenge extends BaseEntity {
 
     @Id

--- a/src/main/java/com/github/nenidan/ne_ne_challenge/domain/challenge/entity/Challenge.java
+++ b/src/main/java/com/github/nenidan/ne_ne_challenge/domain/challenge/entity/Challenge.java
@@ -2,14 +2,18 @@ package com.github.nenidan.ne_ne_challenge.domain.challenge.entity;
 
 import com.github.nenidan.ne_ne_challenge.domain.challenge.type.ChallengeCategory;
 import com.github.nenidan.ne_ne_challenge.domain.challenge.type.ChallengeStatus;
+import com.github.nenidan.ne_ne_challenge.domain.user.entity.User;
 import com.github.nenidan.ne_ne_challenge.global.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 @Entity
 @Getter
+@NoArgsConstructor
 public class Challenge extends BaseEntity {
 
     @Id
@@ -36,5 +40,29 @@ public class Challenge extends BaseEntity {
 
     private LocalDateTime startedAt;
 
-    private LocalDateTime dueAt;
+    private LocalDate dueAt;
+
+    public Challenge(String name,
+        String description,
+        ChallengeStatus status,
+        ChallengeCategory category,
+        int minParticipants,
+        int maxParticipants,
+        int participationFee,
+        LocalDate dueAt
+    ) {
+        this.name = name;
+        this.description = description;
+        this.status = status;
+        this.category = category;
+        this.minParticipants = minParticipants;
+        this.maxParticipants = maxParticipants;
+        this.participationFee = participationFee;
+        this.dueAt = dueAt;
+    }
+
+    // Todo OneToMany로 participants를 받도록 리팩터링 → ChallengeUserService 불필요
+    public void addParticipant(User user) {
+        this.totalFee += this.participationFee;
+    }
 }

--- a/src/main/java/com/github/nenidan/ne_ne_challenge/domain/challenge/entity/ChallengeUser.java
+++ b/src/main/java/com/github/nenidan/ne_ne_challenge/domain/challenge/entity/ChallengeUser.java
@@ -4,10 +4,12 @@ import com.github.nenidan.ne_ne_challenge.domain.user.entity.User;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLRestriction;
 
 @Entity
 @Getter
 @NoArgsConstructor
+@SQLRestriction("deleted_at IS NULL")
 @Table(name = "challenge_user", uniqueConstraints = {@UniqueConstraint(name = "unique_user_id_challenge_id", columnNames = {"user_id", "challenge_id"})})
 public class ChallengeUser {
 

--- a/src/main/java/com/github/nenidan/ne_ne_challenge/domain/challenge/entity/ChallengeUser.java
+++ b/src/main/java/com/github/nenidan/ne_ne_challenge/domain/challenge/entity/ChallengeUser.java
@@ -3,13 +3,15 @@ package com.github.nenidan.ne_ne_challenge.domain.challenge.entity;
 import com.github.nenidan.ne_ne_challenge.domain.user.entity.User;
 import jakarta.persistence.*;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
+@NoArgsConstructor
 public class ChallengeUser {
 
     @Id
-    @GeneratedValue
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
@@ -21,4 +23,10 @@ public class ChallengeUser {
     private Challenge challenge;
 
     private boolean isHost;
+
+    public ChallengeUser(User user, Challenge challenge, boolean isHost) {
+        this.user = user;
+        this.challenge = challenge;
+        this.isHost = isHost;
+    }
 }

--- a/src/main/java/com/github/nenidan/ne_ne_challenge/domain/challenge/entity/ChallengeUser.java
+++ b/src/main/java/com/github/nenidan/ne_ne_challenge/domain/challenge/entity/ChallengeUser.java
@@ -8,6 +8,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @Getter
 @NoArgsConstructor
+@Table(name = "challenge_user", uniqueConstraints = {@UniqueConstraint(name = "unique_user_id_challenge_id", columnNames = {"user_id", "challenge_id"})})
 public class ChallengeUser {
 
     @Id

--- a/src/main/java/com/github/nenidan/ne_ne_challenge/domain/challenge/entity/ChallengeUser.java
+++ b/src/main/java/com/github/nenidan/ne_ne_challenge/domain/challenge/entity/ChallengeUser.java
@@ -1,6 +1,7 @@
 package com.github.nenidan.ne_ne_challenge.domain.challenge.entity;
 
 import com.github.nenidan.ne_ne_challenge.domain.user.entity.User;
+import com.github.nenidan.ne_ne_challenge.global.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -11,7 +12,7 @@ import org.hibernate.annotations.SQLRestriction;
 @NoArgsConstructor
 @SQLRestriction("deleted_at IS NULL")
 @Table(name = "challenge_user", uniqueConstraints = {@UniqueConstraint(name = "unique_user_id_challenge_id", columnNames = {"user_id", "challenge_id"})})
-public class ChallengeUser {
+public class ChallengeUser extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/github/nenidan/ne_ne_challenge/domain/challenge/exception/ChallengeErrorCode.java
+++ b/src/main/java/com/github/nenidan/ne_ne_challenge/domain/challenge/exception/ChallengeErrorCode.java
@@ -9,10 +9,14 @@ import org.springframework.http.HttpStatus;
 @Getter
 public enum ChallengeErrorCode implements ErrorCode {
     CHALLENGE_NOT_FOUND("챌린지를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
-    CHALLENGE_ALREADY_STARTED("이미 시작된 챌린지 입니다.", HttpStatus.CONFLICT),
-    CHALLENGE_ALREADY_ENDED("이미 종료된 챌린지 입니다.", HttpStatus.CONFLICT),
-    CHALLENGE_PARTICIPANT_LIMIT_EXCEEDED("최대 인원이 초과되었습니다.", HttpStatus.CONFLICT),
-    CHALLENGE_MIN_PARTICIPANTS_NOT_MET("최소 인원", HttpStatus.CONFLICT);
+    CHALLENGE_ALREADY_STARTED("이미 시작된 챌린지 입니다.", HttpStatus.BAD_REQUEST),
+    CHALLENGE_ALREADY_FINISHED("이미 종료된 챌린지 입니다.", HttpStatus.BAD_REQUEST),
+    CHALLENGE_PARTICIPANT_LIMIT_EXCEEDED("인원수가 부족하거나 초과합니다.", HttpStatus.BAD_REQUEST),
+    INVALID_PARTICIPANT_LIMIT("올바르지 않은 인원수 제한입니다.", HttpStatus.BAD_REQUEST),
+    NOT_MY_CHALLENGE("참여 중인 챌린지가 아닙니다.", HttpStatus.FORBIDDEN),
+    NOT_HOST("챌린지 수정 권한이 없습니다.", HttpStatus.FORBIDDEN),
+    INVALID_STATUS_TRANSITION("해당 상태로 변경할 수 없습니다.", HttpStatus.BAD_REQUEST),
+    INVALID_DUE_DATE("올바르지 않은 마감일입니다.", HttpStatus.BAD_REQUEST);
 
     private final String message;
     private final HttpStatus status;

--- a/src/main/java/com/github/nenidan/ne_ne_challenge/domain/challenge/repository/ChallengeRepository.java
+++ b/src/main/java/com/github/nenidan/ne_ne_challenge/domain/challenge/repository/ChallengeRepository.java
@@ -20,7 +20,7 @@ public interface ChallengeRepository extends JpaRepository<Challenge, Long> {
         FROM challenge c
         LEFT JOIN challenge_user cu ON cu.challenge_id = c.id AND (:userId IS NULL OR cu.user_id = :userId)
         WHERE(:name IS NULL OR c.name LIKE CONCAT('%', :name, '%'))
-                AND (c.deleted_at IS NOT NULL)
+                AND (c.deleted_at IS NULL)
                 AND (:cursor IS NULL OR c.created_at <= :cursor)
                 AND (:status IS NULL OR c.status = :status)
                 AND (:dueAt IS NULL OR c.due_at < :dueAt)

--- a/src/main/java/com/github/nenidan/ne_ne_challenge/domain/challenge/repository/ChallengeRepository.java
+++ b/src/main/java/com/github/nenidan/ne_ne_challenge/domain/challenge/repository/ChallengeRepository.java
@@ -20,6 +20,7 @@ public interface ChallengeRepository extends JpaRepository<Challenge, Long> {
         FROM challenge c
         LEFT JOIN challenge_user cu ON cu.challenge_id = c.id AND (:userId IS NULL OR cu.user_id = :userId)
         WHERE(:name IS NULL OR c.name LIKE CONCAT('%', :name, '%'))
+                AND (c.deleted_at IS NOT NULL)
                 AND (:cursor IS NULL OR c.created_at <= :cursor)
                 AND (:status IS NULL OR c.status = :status)
                 AND (:dueAt IS NULL OR c.due_at < :dueAt)

--- a/src/main/java/com/github/nenidan/ne_ne_challenge/domain/challenge/repository/ChallengeRepository.java
+++ b/src/main/java/com/github/nenidan/ne_ne_challenge/domain/challenge/repository/ChallengeRepository.java
@@ -1,9 +1,40 @@
 package com.github.nenidan.ne_ne_challenge.domain.challenge.repository;
 
 import com.github.nenidan.ne_ne_challenge.domain.challenge.entity.Challenge;
+import com.github.nenidan.ne_ne_challenge.domain.challenge.type.ChallengeCategory;
+import com.github.nenidan.ne_ne_challenge.domain.challenge.type.ChallengeStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
 
 @Repository
 public interface ChallengeRepository extends JpaRepository<Challenge, Long> {
+
+    @Query(value = """
+        SELECT c.*
+        FROM challenge c
+        LEFT JOIN challenge_user cu ON cu.challenge_id = c.id AND (:userId IS NULL OR cu.user_id = :userId)
+        WHERE(:name IS NULL OR c.name LIKE CONCAT('%', :name, '%'))
+                AND (:cursor IS NULL OR c.created_at <= :cursor)
+                AND (:status IS NULL OR c.status = :status)
+                AND (:dueAt IS NULL OR c.due_at < :dueAt)
+                AND (:category IS NULL OR c.category = :category)
+                AND (:maxParticipationFee IS NULL OR c.participation_fee <= :maxParticipationFee)
+        ORDER BY c.created_at DESC
+        LIMIT :limit
+        """, nativeQuery = true)
+    List<Challenge> getChallengeList(@Param("userId") Long userId,
+        @Param("name") String name,
+        @Param("status") ChallengeStatus status,
+        @Param("dueAt") LocalDate dueAt,
+        @Param("category") ChallengeCategory category,
+        @Param("maxParticipationFee") Integer maxParticipationFee,
+        @Param("cursor") LocalDateTime cursor,
+        @Param("limit") int limit
+    );
 }

--- a/src/main/java/com/github/nenidan/ne_ne_challenge/domain/challenge/repository/ChallengeUserRepository.java
+++ b/src/main/java/com/github/nenidan/ne_ne_challenge/domain/challenge/repository/ChallengeUserRepository.java
@@ -1,0 +1,10 @@
+package com.github.nenidan.ne_ne_challenge.domain.challenge.repository;
+
+import com.github.nenidan.ne_ne_challenge.domain.challenge.entity.ChallengeUser;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ChallengeUserRepository extends JpaRepository<ChallengeUser, Long> {
+
+}

--- a/src/main/java/com/github/nenidan/ne_ne_challenge/domain/challenge/repository/ChallengeUserRepository.java
+++ b/src/main/java/com/github/nenidan/ne_ne_challenge/domain/challenge/repository/ChallengeUserRepository.java
@@ -1,10 +1,20 @@
 package com.github.nenidan.ne_ne_challenge.domain.challenge.repository;
 
+import com.github.nenidan.ne_ne_challenge.domain.challenge.entity.Challenge;
 import com.github.nenidan.ne_ne_challenge.domain.challenge.entity.ChallengeUser;
+import com.github.nenidan.ne_ne_challenge.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface ChallengeUserRepository extends JpaRepository<ChallengeUser, Long> {
 
+    List<ChallengeUser> findByUser(User user);
+
+    Optional<ChallengeUser> findByUserAndChallenge(User user, Challenge challenge);
+
+    int countByChallenge(Challenge challenge);
 }

--- a/src/main/java/com/github/nenidan/ne_ne_challenge/domain/challenge/service/ChallengeService.java
+++ b/src/main/java/com/github/nenidan/ne_ne_challenge/domain/challenge/service/ChallengeService.java
@@ -49,7 +49,6 @@ public class ChallengeService {
         return ChallengeResponse.from(savedChallenge);
     }
 
-    // fixme: soft-delete 된 항목 조회 x
     public ChallengeResponse getChallenge(Long id) {
         Challenge foundChallenge = challengeRepository.findById(id).orElseThrow(() -> new ChallengeException(
             ChallengeErrorCode.CHALLENGE_NOT_FOUND));
@@ -57,7 +56,6 @@ public class ChallengeService {
         return ChallengeResponse.from(foundChallenge);
     }
 
-    // fixme: soft-delete 된 항목 조회 x
     public CursorResponse<ChallengeResponse, LocalDateTime> getChallengeList(ChallengeSearchCond cond) {
         int size = cond.getSize();
 
@@ -117,7 +115,6 @@ public class ChallengeService {
         return ChallengeResponse.from(challenge);
     }
 
-    // fixme: soft-delete 된 항목 조회 x
     // todo: 여러 번의 리포지토리 호출 조인으로 한 번에? 엔티티 연관관계부터 수정 필요할 듯
     @Transactional
     public Void deleteChallenge(Long userId, Long challengeId) {

--- a/src/main/java/com/github/nenidan/ne_ne_challenge/domain/challenge/service/ChallengeService.java
+++ b/src/main/java/com/github/nenidan/ne_ne_challenge/domain/challenge/service/ChallengeService.java
@@ -1,12 +1,36 @@
 package com.github.nenidan.ne_ne_challenge.domain.challenge.service;
 
+import com.github.nenidan.ne_ne_challenge.domain.challenge.dto.request.CreateChallengeRequest;
+import com.github.nenidan.ne_ne_challenge.domain.challenge.dto.response.ChallengeResponse;
+import com.github.nenidan.ne_ne_challenge.domain.challenge.entity.Challenge;
 import com.github.nenidan.ne_ne_challenge.domain.challenge.repository.ChallengeRepository;
+import com.github.nenidan.ne_ne_challenge.domain.user.entity.User;
+import com.github.nenidan.ne_ne_challenge.domain.user.exception.UserErrorCode;
+import com.github.nenidan.ne_ne_challenge.domain.user.exception.UserException;
+import com.github.nenidan.ne_ne_challenge.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
+@Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class ChallengeService {
 
+    private final ChallengeUserService challengeUserService;
+
     private final ChallengeRepository challengeRepository;
+
+    private final UserRepository userRepository;
+
+    @Transactional
+    public ChallengeResponse createChallenge(CreateChallengeRequest request, Long userId) {
+        User user = userRepository.findById(userId).orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
+        Challenge newChallenge = request.toEntity();
+
+        Challenge savedChallenge = challengeRepository.save(newChallenge);
+        challengeUserService.joinChallenge(user.getId(), savedChallenge.getId(), true);
+
+        return ChallengeResponse.from(savedChallenge);
+    }
 }

--- a/src/main/java/com/github/nenidan/ne_ne_challenge/domain/challenge/service/ChallengeService.java
+++ b/src/main/java/com/github/nenidan/ne_ne_challenge/domain/challenge/service/ChallengeService.java
@@ -77,8 +77,11 @@ public class ChallengeService {
     }
 
     /**
-     * 챌린지 상태 수정: WAITING → ONGOING → FINISHED 순서로만 가능
-     * 참가비 수정 시에는 차이만큼 다시 지급하거나 지불해야 하며, 시작 후 수정 불가능 → 아직 미구현
+     * 챌린지 상태 수정: WAITING → ONGOING만 가능
+     * name, description, category는 자유롭게 변경 가능
+     * dueAt 은 오늘보다 이전으로 설정 불가
+     * minParticipants <= maxParticipants 여야 하며, minParticipants가 현재 참여자보다 작아지면 자동 시작
+     * 참가비 수정 시에는 차이만큼 다시 지급하거나 지불해야 하며, 시작 후 수정 불가 → 아직 미구현
      * 불가능한 조건이 존재할 시 모든 변경 취소
      *
      * @param userId:      요청자 id

--- a/src/main/java/com/github/nenidan/ne_ne_challenge/domain/challenge/service/ChallengeService.java
+++ b/src/main/java/com/github/nenidan/ne_ne_challenge/domain/challenge/service/ChallengeService.java
@@ -39,8 +39,8 @@ public class ChallengeService {
     private final ChallengeUserRepository challengeUserRepository;
 
     @Transactional
-    public ChallengeResponse createChallenge(CreateChallengeRequest request, Long userId) {
-        User user = userRepository.findById(userId).orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
+    public ChallengeResponse createChallenge(CreateChallengeRequest request) {
+        User user = userRepository.findById(request.getUserId()).orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
         Challenge newChallenge = request.toEntity();
 
         Challenge savedChallenge = challengeRepository.save(newChallenge);
@@ -84,14 +84,13 @@ public class ChallengeService {
      * 참가비 수정 시에는 차이만큼 다시 지급하거나 지불해야 하며, 시작 후 수정 불가 → 아직 미구현
      * 불가능한 조건이 존재할 시 모든 변경 취소
      *
-     * @param userId:      요청자 id
      * @param challengeId: 챌린지 id
-     * @param request:     바꿀 정보를 담고 있는 DTO
+     * @param request:     요청 정보
      * @return 변경된 챌린지 정보
      */
     @Transactional
-    public ChallengeResponse updateChallenge(Long userId, Long challengeId, UpdateChallengeRequest request) {
-        User user = userRepository.findById(userId)
+    public ChallengeResponse updateChallenge(Long challengeId, UpdateChallengeRequest request) {
+        User user = userRepository.findById(request.getUserId())
             .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
         Challenge challenge = challengeRepository.findById(challengeId)
             .orElseThrow(() -> new ChallengeException(ChallengeErrorCode.CHALLENGE_NOT_FOUND));

--- a/src/main/java/com/github/nenidan/ne_ne_challenge/domain/challenge/service/ChallengeService.java
+++ b/src/main/java/com/github/nenidan/ne_ne_challenge/domain/challenge/service/ChallengeService.java
@@ -1,16 +1,23 @@
 package com.github.nenidan.ne_ne_challenge.domain.challenge.service;
 
+import com.github.nenidan.ne_ne_challenge.domain.challenge.dto.request.ChallengeSearchCond;
 import com.github.nenidan.ne_ne_challenge.domain.challenge.dto.request.CreateChallengeRequest;
 import com.github.nenidan.ne_ne_challenge.domain.challenge.dto.response.ChallengeResponse;
 import com.github.nenidan.ne_ne_challenge.domain.challenge.entity.Challenge;
+import com.github.nenidan.ne_ne_challenge.domain.challenge.exception.ChallengeErrorCode;
+import com.github.nenidan.ne_ne_challenge.domain.challenge.exception.ChallengeException;
 import com.github.nenidan.ne_ne_challenge.domain.challenge.repository.ChallengeRepository;
 import com.github.nenidan.ne_ne_challenge.domain.user.entity.User;
 import com.github.nenidan.ne_ne_challenge.domain.user.exception.UserErrorCode;
 import com.github.nenidan.ne_ne_challenge.domain.user.exception.UserException;
 import com.github.nenidan.ne_ne_challenge.domain.user.repository.UserRepository;
+import com.github.nenidan.ne_ne_challenge.global.dto.CursorResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
 
 @Service
 @Transactional(readOnly = true)
@@ -32,5 +39,34 @@ public class ChallengeService {
         challengeUserService.joinChallenge(user.getId(), savedChallenge.getId(), true);
 
         return ChallengeResponse.from(savedChallenge);
+    }
+
+    public ChallengeResponse getChallenge(Long id) {
+        Challenge foundChallenge = challengeRepository.findById(id).orElseThrow(() -> new ChallengeException(
+            ChallengeErrorCode.CHALLENGE_NOT_FOUND));
+
+        return ChallengeResponse.from(foundChallenge);
+    }
+
+    public CursorResponse<ChallengeResponse, LocalDateTime> getChallengeList(ChallengeSearchCond cond) {
+        int size = cond.getSize();
+
+        List<ChallengeResponse> challengeList = challengeRepository.getChallengeList(cond.getUserId(),
+            cond.getName(),
+            cond.getStatus(),
+            cond.getDueAt(),
+            cond.getCategory(),
+            cond.getMaxParticipationFee(),
+            cond.getCursor(),
+            size + 1
+        ).stream()
+            .map(ChallengeResponse::from)
+            .toList();
+
+        boolean hasNext = challengeList.size() > size;
+        List<ChallengeResponse> content = hasNext ? challengeList.subList(0, size) : challengeList;
+        LocalDateTime nextCursor = hasNext ? challengeList.get(challengeList.size() - 1).getCreatedAt() : null;
+
+        return CursorResponse.of(content, nextCursor, hasNext);
     }
 }

--- a/src/main/java/com/github/nenidan/ne_ne_challenge/domain/challenge/service/ChallengeUserService.java
+++ b/src/main/java/com/github/nenidan/ne_ne_challenge/domain/challenge/service/ChallengeUserService.java
@@ -1,0 +1,40 @@
+package com.github.nenidan.ne_ne_challenge.domain.challenge.service;
+
+import com.github.nenidan.ne_ne_challenge.domain.challenge.entity.Challenge;
+import com.github.nenidan.ne_ne_challenge.domain.challenge.entity.ChallengeUser;
+import com.github.nenidan.ne_ne_challenge.domain.challenge.exception.ChallengeErrorCode;
+import com.github.nenidan.ne_ne_challenge.domain.challenge.exception.ChallengeException;
+import com.github.nenidan.ne_ne_challenge.domain.challenge.repository.ChallengeRepository;
+import com.github.nenidan.ne_ne_challenge.domain.challenge.repository.ChallengeUserRepository;
+import com.github.nenidan.ne_ne_challenge.domain.user.entity.User;
+import com.github.nenidan.ne_ne_challenge.domain.user.exception.UserErrorCode;
+import com.github.nenidan.ne_ne_challenge.domain.user.exception.UserException;
+import com.github.nenidan.ne_ne_challenge.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class ChallengeUserService {
+
+    private final UserRepository userRepository;
+
+    private final ChallengeRepository challengeRepository;
+
+    private final ChallengeUserRepository challengeUserRepository;
+    
+    @Transactional
+    public void joinChallenge(long userId, long challengeId, boolean isHost) {
+        User user = userRepository.findById(userId).orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
+        Challenge challenge = challengeRepository.findById(challengeId).orElseThrow(() -> new ChallengeException(
+            ChallengeErrorCode.CHALLENGE_NOT_FOUND));
+
+        // Todo 사용자의 포인트 검증
+        challenge.addParticipant(user);
+        ChallengeUser challengeUser = new ChallengeUser(user, challenge, isHost);
+        
+        challengeUserRepository.save(challengeUser);
+    }
+}


### PR DESCRIPTION
## 변경 사항
- 새로운 챌린지 생성 기능 추가
- 챌린지 목록 조회 기능 추가
- 챌린지 단건 조회 기능 추가
- 챌린지 정보 수정 기능 추가: 내부적으로 조건을 만족해야만 변경 가능
- 챌린지 삭제 기능 추가

## 주의 사항
- 포인트 구현 후 관련 로직 변경 필요
- 빈 검증 없음
- 예외 처리 완벽하지 않음
- 현재 수정 로직이 서비스와 엔티티에 나눠져있음