### PR TITLE
챌린지 포인트 이외 기능

### DIFF
--- a/src/main/java/com/github/nenidan/ne_ne_challenge/domain/challenge/controller/ChallengeController.java
+++ b/src/main/java/com/github/nenidan/ne_ne_challenge/domain/challenge/controller/ChallengeController.java
@@ -4,6 +4,8 @@ import com.github.nenidan.ne_ne_challenge.domain.challenge.dto.request.Challenge
 import com.github.nenidan.ne_ne_challenge.domain.challenge.dto.request.CreateChallengeRequest;
 import com.github.nenidan.ne_ne_challenge.domain.challenge.dto.request.UpdateChallengeRequest;
 import com.github.nenidan.ne_ne_challenge.domain.challenge.dto.response.ChallengeResponse;
+import com.github.nenidan.ne_ne_challenge.domain.challenge.dto.response.ChallengeSuccessRateResponse;
+import com.github.nenidan.ne_ne_challenge.domain.challenge.service.ChallengeHistoryService;
 import com.github.nenidan.ne_ne_challenge.domain.challenge.service.ChallengeService;
 import com.github.nenidan.ne_ne_challenge.domain.challenge.service.ChallengeUserService;
 import com.github.nenidan.ne_ne_challenge.domain.user.dto.response.UserResponse;
@@ -25,6 +27,8 @@ public class ChallengeController {
     private final ChallengeService challengeService;
 
     private final ChallengeUserService challengeUserService;
+
+    private final ChallengeHistoryService challengeHistoryService;
 
     @PostMapping("/challenges")
     public ResponseEntity<ApiResponse<ChallengeResponse>> createChallenge(@RequestBody CreateChallengeRequest request) {
@@ -61,6 +65,16 @@ public class ChallengeController {
         return ApiResponse.success(HttpStatus.OK,
             "챌린지 참가자 목록을 조회했습니다.",
             challengeUserService.getChallengeParticipantList(id, cursor, size)
+        );
+    }
+
+    @GetMapping("/challenges/{id}/success-rate")
+    public ResponseEntity<ApiResponse<ChallengeSuccessRateResponse>> getSuccessRate(@PathVariable Long id,
+        @RequestParam Long userId
+    ) {
+        return ApiResponse.success(HttpStatus.OK,
+            "현재까지의 인증율을 조회했습니다.",
+            challengeHistoryService.getSuccessRate(userId, id)
         );
     }
 }

--- a/src/main/java/com/github/nenidan/ne_ne_challenge/domain/challenge/controller/ChallengeController.java
+++ b/src/main/java/com/github/nenidan/ne_ne_challenge/domain/challenge/controller/ChallengeController.java
@@ -5,8 +5,11 @@ import com.github.nenidan.ne_ne_challenge.domain.challenge.dto.request.CreateCha
 import com.github.nenidan.ne_ne_challenge.domain.challenge.dto.request.UpdateChallengeRequest;
 import com.github.nenidan.ne_ne_challenge.domain.challenge.dto.response.ChallengeResponse;
 import com.github.nenidan.ne_ne_challenge.domain.challenge.service.ChallengeService;
+import com.github.nenidan.ne_ne_challenge.domain.challenge.service.ChallengeUserService;
+import com.github.nenidan.ne_ne_challenge.domain.user.dto.response.UserResponse;
 import com.github.nenidan.ne_ne_challenge.global.dto.ApiResponse;
 import com.github.nenidan.ne_ne_challenge.global.dto.CursorResponse;
+import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -20,6 +23,8 @@ import java.time.LocalDateTime;
 public class ChallengeController {
 
     private final ChallengeService challengeService;
+
+    private final ChallengeUserService challengeUserService;
 
     @PostMapping("/challenges")
     public ResponseEntity<ApiResponse<ChallengeResponse>> createChallenge(@RequestBody CreateChallengeRequest request) {
@@ -46,5 +51,16 @@ public class ChallengeController {
     @DeleteMapping("/challenges/{id}")
     public ResponseEntity<ApiResponse<Void>> deleteChallenge(@PathVariable Long id, @RequestParam Long userId) {
         return ApiResponse.success(HttpStatus.OK, "챌린지를 삭제했습니다.", challengeService.deleteChallenge(userId, id));
+    }
+
+    @GetMapping("/challenges/{id}/participants")
+    public ResponseEntity<ApiResponse<CursorResponse<UserResponse, Long>>> getChallengeParticipantList(@RequestParam(defaultValue = "0") Long cursor,
+        @RequestParam(defaultValue = "10") @Min(1) int size,
+        @PathVariable Long id
+    ) {
+        return ApiResponse.success(HttpStatus.OK,
+            "챌린지 참가자 목록을 조회했습니다.",
+            challengeUserService.getChallengeParticipantList(id, cursor, size)
+        );
     }
 }

--- a/src/main/java/com/github/nenidan/ne_ne_challenge/domain/challenge/controller/ChallengeHistoryController.java
+++ b/src/main/java/com/github/nenidan/ne_ne_challenge/domain/challenge/controller/ChallengeHistoryController.java
@@ -1,15 +1,19 @@
 package com.github.nenidan.ne_ne_challenge.domain.challenge.controller;
 
 import com.github.nenidan.ne_ne_challenge.domain.challenge.dto.request.CreateHistoryRequest;
+import com.github.nenidan.ne_ne_challenge.domain.challenge.dto.request.HistorySearchCond;
 import com.github.nenidan.ne_ne_challenge.domain.challenge.dto.response.ChallengeHistoryResponse;
 import com.github.nenidan.ne_ne_challenge.domain.challenge.service.ChallengeHistoryService;
 import com.github.nenidan.ne_ne_challenge.global.dto.ApiResponse;
+import com.github.nenidan.ne_ne_challenge.global.dto.CursorResponse;
 import com.github.nenidan.ne_ne_challenge.global.security.auth.Auth;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDateTime;
 
 @RestController
 @RequestMapping("/api")
@@ -26,6 +30,16 @@ public class ChallengeHistoryController {
         return ApiResponse.success(HttpStatus.CREATED,
             "챌린지 기록을 남겼습니다.",
             challengeHistoryService.createHistory(request, authUser.getId(), id)
+        );
+    }
+
+    @GetMapping("/challenges/{id}/history")
+    public ResponseEntity<ApiResponse<CursorResponse<ChallengeHistoryResponse, LocalDateTime>>> getHistoryList(@PathVariable Long id,
+        @ModelAttribute HistorySearchCond cond
+    ) {
+        return ApiResponse.success(HttpStatus.OK,
+            "챌린지 기록을 조회했습니다.",
+            challengeHistoryService.getHistoryList(id, cond)
         );
     }
 }

--- a/src/main/java/com/github/nenidan/ne_ne_challenge/domain/challenge/controller/ChallengeHistoryController.java
+++ b/src/main/java/com/github/nenidan/ne_ne_challenge/domain/challenge/controller/ChallengeHistoryController.java
@@ -1,0 +1,31 @@
+package com.github.nenidan.ne_ne_challenge.domain.challenge.controller;
+
+import com.github.nenidan.ne_ne_challenge.domain.challenge.dto.request.CreateHistoryRequest;
+import com.github.nenidan.ne_ne_challenge.domain.challenge.dto.response.ChallengeHistoryResponse;
+import com.github.nenidan.ne_ne_challenge.domain.challenge.service.ChallengeHistoryService;
+import com.github.nenidan.ne_ne_challenge.global.dto.ApiResponse;
+import com.github.nenidan.ne_ne_challenge.global.security.auth.Auth;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api")
+@RequiredArgsConstructor
+public class ChallengeHistoryController {
+
+    private final ChallengeHistoryService challengeHistoryService;
+
+    @PostMapping("/challenges/{id}/history")
+    public ResponseEntity<ApiResponse<ChallengeHistoryResponse>> verifyProgress(@AuthenticationPrincipal Auth authUser,
+        @PathVariable Long id,
+        @RequestBody CreateHistoryRequest request
+    ) {
+        return ApiResponse.success(HttpStatus.CREATED,
+            "챌린지 기록을 남겼습니다.",
+            challengeHistoryService.createHistory(request, authUser.getId(), id)
+        );
+    }
+}

--- a/src/main/java/com/github/nenidan/ne_ne_challenge/domain/challenge/dto/request/CreateHistoryRequest.java
+++ b/src/main/java/com/github/nenidan/ne_ne_challenge/domain/challenge/dto/request/CreateHistoryRequest.java
@@ -1,0 +1,10 @@
+package com.github.nenidan.ne_ne_challenge.domain.challenge.dto.request;
+
+import lombok.Getter;
+
+// todo: 빈 검증
+@Getter
+public class CreateHistoryRequest {
+
+    private String content;
+}

--- a/src/main/java/com/github/nenidan/ne_ne_challenge/domain/challenge/dto/request/HistorySearchCond.java
+++ b/src/main/java/com/github/nenidan/ne_ne_challenge/domain/challenge/dto/request/HistorySearchCond.java
@@ -1,0 +1,18 @@
+package com.github.nenidan.ne_ne_challenge.domain.challenge.dto.request;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+// Todo 빈 검증 제약 조건
+@Getter
+@Setter
+public class HistorySearchCond {
+
+    private Long userId;
+
+    private LocalDateTime cursor = LocalDateTime.of(9999, 12, 31, 23, 59, 59);
+
+    private int size = 10;
+}

--- a/src/main/java/com/github/nenidan/ne_ne_challenge/domain/challenge/dto/response/ChallengeHistoryResponse.java
+++ b/src/main/java/com/github/nenidan/ne_ne_challenge/domain/challenge/dto/response/ChallengeHistoryResponse.java
@@ -1,0 +1,35 @@
+package com.github.nenidan.ne_ne_challenge.domain.challenge.dto.response;
+
+import com.github.nenidan.ne_ne_challenge.domain.challenge.entity.ChallengeHistory;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class ChallengeHistoryResponse {
+
+    private Long id;
+
+    private Long userId;
+
+    private Long challengeId;
+
+    private String content;
+
+    private boolean isSuccess;
+
+    private LocalDateTime createdAt;
+
+    public static ChallengeHistoryResponse from(ChallengeHistory history) {
+        return new ChallengeHistoryResponse(history.getId(),
+            history.getUser().getId(),
+            history.getChallenge().getId(),
+            history.getContent(),
+            history.isSuccess(),
+            history.getCreatedAt()
+        );
+    }
+}

--- a/src/main/java/com/github/nenidan/ne_ne_challenge/domain/challenge/dto/response/ChallengeSuccessRateResponse.java
+++ b/src/main/java/com/github/nenidan/ne_ne_challenge/domain/challenge/dto/response/ChallengeSuccessRateResponse.java
@@ -1,0 +1,13 @@
+package com.github.nenidan.ne_ne_challenge.domain.challenge.dto.response;
+
+import lombok.Getter;
+
+@Getter
+public class ChallengeSuccessRateResponse {
+
+    public ChallengeSuccessRateResponse(int successRate) {
+        this.successRate = successRate;
+    }
+
+    private int successRate;
+}

--- a/src/main/java/com/github/nenidan/ne_ne_challenge/domain/challenge/entity/ChallengeHistory.java
+++ b/src/main/java/com/github/nenidan/ne_ne_challenge/domain/challenge/entity/ChallengeHistory.java
@@ -4,10 +4,14 @@ import com.github.nenidan.ne_ne_challenge.domain.user.entity.User;
 import com.github.nenidan.ne_ne_challenge.global.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLRestriction;
 
 @Entity
 @Getter
-public class ChallengeLog extends BaseEntity {
+@NoArgsConstructor
+@SQLRestriction("deleted_at IS NULL")
+public class ChallengeHistory extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -24,4 +28,11 @@ public class ChallengeLog extends BaseEntity {
     private String content; // Todo: 인증방식 변경
 
     private boolean isSuccess;
+
+    public ChallengeHistory(User user, Challenge challenge, String content, boolean isSuccess) {
+        this.user = user;
+        this.challenge = challenge;
+        this.content = content;
+        this.isSuccess = isSuccess;
+    }
 }

--- a/src/main/java/com/github/nenidan/ne_ne_challenge/domain/challenge/exception/ChallengeErrorCode.java
+++ b/src/main/java/com/github/nenidan/ne_ne_challenge/domain/challenge/exception/ChallengeErrorCode.java
@@ -16,7 +16,8 @@ public enum ChallengeErrorCode implements ErrorCode {
     NOT_MY_CHALLENGE("참여 중인 챌린지가 아닙니다.", HttpStatus.FORBIDDEN),
     NOT_HOST("챌린지 수정 권한이 없습니다.", HttpStatus.FORBIDDEN),
     INVALID_STATUS_TRANSITION("해당 상태로 변경할 수 없습니다.", HttpStatus.BAD_REQUEST),
-    INVALID_DUE_DATE("올바르지 않은 마감일입니다.", HttpStatus.BAD_REQUEST);
+    INVALID_DUE_DATE("올바르지 않은 마감일입니다.", HttpStatus.BAD_REQUEST),
+    ALREADY_VERIFIED("이미 오늘의 기록을 남겼습니다.", HttpStatus.BAD_REQUEST);
 
     private final String message;
     private final HttpStatus status;

--- a/src/main/java/com/github/nenidan/ne_ne_challenge/domain/challenge/exception/ChallengeErrorCode.java
+++ b/src/main/java/com/github/nenidan/ne_ne_challenge/domain/challenge/exception/ChallengeErrorCode.java
@@ -17,7 +17,8 @@ public enum ChallengeErrorCode implements ErrorCode {
     NOT_HOST("챌린지 수정 권한이 없습니다.", HttpStatus.FORBIDDEN),
     INVALID_STATUS_TRANSITION("해당 상태로 변경할 수 없습니다.", HttpStatus.BAD_REQUEST),
     INVALID_DUE_DATE("올바르지 않은 마감일입니다.", HttpStatus.BAD_REQUEST),
-    ALREADY_VERIFIED("이미 오늘의 기록을 남겼습니다.", HttpStatus.BAD_REQUEST);
+    ALREADY_VERIFIED("이미 오늘의 기록을 남겼습니다.", HttpStatus.BAD_REQUEST),
+    NOT_STARTED("아직 시작하지 않은 챌린지입니다.", HttpStatus.BAD_REQUEST);
 
     private final String message;
     private final HttpStatus status;

--- a/src/main/java/com/github/nenidan/ne_ne_challenge/domain/challenge/exception/ChallengeErrorCode.java
+++ b/src/main/java/com/github/nenidan/ne_ne_challenge/domain/challenge/exception/ChallengeErrorCode.java
@@ -13,7 +13,7 @@ public enum ChallengeErrorCode implements ErrorCode {
     CHALLENGE_ALREADY_FINISHED("이미 종료된 챌린지 입니다.", HttpStatus.BAD_REQUEST),
     CHALLENGE_PARTICIPANT_LIMIT_EXCEEDED("인원수가 부족하거나 초과합니다.", HttpStatus.BAD_REQUEST),
     INVALID_PARTICIPANT_LIMIT("올바르지 않은 인원수 제한입니다.", HttpStatus.BAD_REQUEST),
-    NOT_MY_CHALLENGE("참여 중인 챌린지가 아닙니다.", HttpStatus.FORBIDDEN),
+    NOT_PARTICIPATING("참여 중인 챌린지가 아닙니다.", HttpStatus.FORBIDDEN),
     NOT_HOST("챌린지 수정 권한이 없습니다.", HttpStatus.FORBIDDEN),
     INVALID_STATUS_TRANSITION("해당 상태로 변경할 수 없습니다.", HttpStatus.BAD_REQUEST),
     INVALID_DUE_DATE("올바르지 않은 마감일입니다.", HttpStatus.BAD_REQUEST),

--- a/src/main/java/com/github/nenidan/ne_ne_challenge/domain/challenge/repository/ChallengeHistoryRepository.java
+++ b/src/main/java/com/github/nenidan/ne_ne_challenge/domain/challenge/repository/ChallengeHistoryRepository.java
@@ -1,0 +1,27 @@
+package com.github.nenidan.ne_ne_challenge.domain.challenge.repository;
+
+import com.github.nenidan.ne_ne_challenge.domain.challenge.entity.ChallengeHistory;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+
+@Repository
+public interface ChallengeHistoryRepository extends JpaRepository<ChallengeHistory, Long> {
+
+    @Query("""
+            SELECT COUNT(ch)
+            FROM ChallengeHistory ch
+            WHERE ch.createdAt >= :startOfDay
+            AND ch.createdAt < :endOfDay
+            AND ch.user.id = :userId
+            AND ch.challenge.id = :challengeId
+        """)
+    Long countTodayHistory(@Param("userId") Long userId,
+        @Param("challengeId") Long challengeId,
+        @Param("startOfDay") LocalDateTime startOfDay,
+        @Param("endOfDay") LocalDateTime endOfDay
+    );
+}

--- a/src/main/java/com/github/nenidan/ne_ne_challenge/domain/challenge/repository/ChallengeHistoryRepository.java
+++ b/src/main/java/com/github/nenidan/ne_ne_challenge/domain/challenge/repository/ChallengeHistoryRepository.java
@@ -1,12 +1,17 @@
 package com.github.nenidan.ne_ne_challenge.domain.challenge.repository;
 
+import com.github.nenidan.ne_ne_challenge.domain.challenge.entity.Challenge;
 import com.github.nenidan.ne_ne_challenge.domain.challenge.entity.ChallengeHistory;
+import com.github.nenidan.ne_ne_challenge.domain.challenge.type.ChallengeCategory;
+import com.github.nenidan.ne_ne_challenge.domain.challenge.type.ChallengeStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Repository
 public interface ChallengeHistoryRepository extends JpaRepository<ChallengeHistory, Long> {
@@ -23,5 +28,20 @@ public interface ChallengeHistoryRepository extends JpaRepository<ChallengeHisto
         @Param("challengeId") Long challengeId,
         @Param("startOfDay") LocalDateTime startOfDay,
         @Param("endOfDay") LocalDateTime endOfDay
+    );
+
+    @Query(value = """
+        SELECT ch.*
+        FROM challenge_history ch
+        WHERE ch.user_id = :userId
+        AND ch.challenge_id = :challengeId
+        AND (:cursor IS NULL OR ch.created_at <= :cursor)
+        ORDER BY ch.created_at DESC
+        LIMIT :limit
+        """, nativeQuery = true)
+    List<ChallengeHistory> getChallengeHistoryList(@Param("userId") Long userId,
+        @Param("challengeId") Long challengeId,
+        @Param("cursor") LocalDateTime cursor,
+        @Param("limit") int limit
     );
 }

--- a/src/main/java/com/github/nenidan/ne_ne_challenge/domain/challenge/repository/ChallengeHistoryRepository.java
+++ b/src/main/java/com/github/nenidan/ne_ne_challenge/domain/challenge/repository/ChallengeHistoryRepository.java
@@ -4,6 +4,7 @@ import com.github.nenidan.ne_ne_challenge.domain.challenge.entity.Challenge;
 import com.github.nenidan.ne_ne_challenge.domain.challenge.entity.ChallengeHistory;
 import com.github.nenidan.ne_ne_challenge.domain.challenge.type.ChallengeCategory;
 import com.github.nenidan.ne_ne_challenge.domain.challenge.type.ChallengeStatus;
+import com.github.nenidan.ne_ne_challenge.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -44,4 +45,6 @@ public interface ChallengeHistoryRepository extends JpaRepository<ChallengeHisto
         @Param("cursor") LocalDateTime cursor,
         @Param("limit") int limit
     );
+
+    int countByChallengeAndUserAndIsSuccessTrue(Challenge challenge, User user);
 }

--- a/src/main/java/com/github/nenidan/ne_ne_challenge/domain/challenge/repository/ChallengeUserRepository.java
+++ b/src/main/java/com/github/nenidan/ne_ne_challenge/domain/challenge/repository/ChallengeUserRepository.java
@@ -4,6 +4,8 @@ import com.github.nenidan.ne_ne_challenge.domain.challenge.entity.Challenge;
 import com.github.nenidan.ne_ne_challenge.domain.challenge.entity.ChallengeUser;
 import com.github.nenidan.ne_ne_challenge.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -17,4 +19,16 @@ public interface ChallengeUserRepository extends JpaRepository<ChallengeUser, Lo
     Optional<ChallengeUser> findByUserAndChallenge(User user, Challenge challenge);
 
     int countByChallenge(Challenge challenge);
+
+    @Query(value = """
+        SELECT u.*
+        FROM user u JOIN challenge_user cu ON cu.user_id = u.id
+        WHERE u.deleted_at IS NULL
+        AND cu.deleted_at IS NULL
+        AND :challenge_id = cu.challenge_id
+        AND u.id >= :cursor
+        ORDER BY user_id
+        LIMIT :limit
+        """, nativeQuery = true)
+    List<User> getParticipantList(@Param("challenge_id") Long id, @Param("cursor") Long cursor, @Param("limit") int limit);
 }

--- a/src/main/java/com/github/nenidan/ne_ne_challenge/domain/challenge/service/ChallengeHistoryService.java
+++ b/src/main/java/com/github/nenidan/ne_ne_challenge/domain/challenge/service/ChallengeHistoryService.java
@@ -1,0 +1,57 @@
+package com.github.nenidan.ne_ne_challenge.domain.challenge.service;
+
+import com.github.nenidan.ne_ne_challenge.domain.challenge.dto.request.CreateHistoryRequest;
+import com.github.nenidan.ne_ne_challenge.domain.challenge.dto.response.ChallengeHistoryResponse;
+import com.github.nenidan.ne_ne_challenge.domain.challenge.entity.Challenge;
+import com.github.nenidan.ne_ne_challenge.domain.challenge.entity.ChallengeHistory;
+import com.github.nenidan.ne_ne_challenge.domain.challenge.entity.ChallengeUser;
+import com.github.nenidan.ne_ne_challenge.domain.challenge.exception.ChallengeErrorCode;
+import com.github.nenidan.ne_ne_challenge.domain.challenge.exception.ChallengeException;
+import com.github.nenidan.ne_ne_challenge.domain.challenge.repository.ChallengeHistoryRepository;
+import com.github.nenidan.ne_ne_challenge.domain.challenge.repository.ChallengeRepository;
+import com.github.nenidan.ne_ne_challenge.domain.challenge.repository.ChallengeUserRepository;
+import com.github.nenidan.ne_ne_challenge.domain.user.entity.User;
+import com.github.nenidan.ne_ne_challenge.domain.user.exception.UserErrorCode;
+import com.github.nenidan.ne_ne_challenge.domain.user.exception.UserException;
+import com.github.nenidan.ne_ne_challenge.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+
+import static com.github.nenidan.ne_ne_challenge.domain.challenge.exception.ChallengeErrorCode.ALREADY_VERIFIED;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class ChallengeHistoryService {
+
+    private final UserRepository userRepository;
+    private final ChallengeRepository challengeRepository;
+    private final ChallengeUserRepository challengeUserRepository;
+    private final ChallengeHistoryRepository challengeHistoryRepository;
+
+    @Transactional
+    public ChallengeHistoryResponse createHistory(CreateHistoryRequest request, Long userId, Long challengeId) {
+        User user = userRepository.findById(userId)
+            .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
+        Challenge challenge = challengeRepository.findById(challengeId)
+            .orElseThrow(() -> new ChallengeException(ChallengeErrorCode.CHALLENGE_NOT_FOUND));
+        ChallengeUser challengeUser = challengeUserRepository.findByUserAndChallenge(user, challenge)
+            .orElseThrow(() -> new ChallengeException(ChallengeErrorCode.NOT_MY_CHALLENGE));
+
+        LocalDateTime startOfDay = LocalDateTime.now().truncatedTo(ChronoUnit.DAYS);
+        LocalDateTime endOfDay = startOfDay.plusDays(1);
+        Long count = challengeHistoryRepository.countTodayHistory(userId, challengeId, startOfDay, endOfDay);
+        if (count > 0) {
+            throw new ChallengeException(ALREADY_VERIFIED);
+        }
+
+        ChallengeHistory newHistory = new ChallengeHistory(user, challenge, request.getContent(), true); // Todo: 현재는 그냥 성공처리
+
+        ChallengeHistory savedHistory = challengeHistoryRepository.save(newHistory);
+        return ChallengeHistoryResponse.from(savedHistory);
+    }
+}

--- a/src/main/java/com/github/nenidan/ne_ne_challenge/domain/challenge/service/ChallengeService.java
+++ b/src/main/java/com/github/nenidan/ne_ne_challenge/domain/challenge/service/ChallengeService.java
@@ -95,7 +95,7 @@ public class ChallengeService {
         Challenge challenge = challengeRepository.findById(challengeId)
             .orElseThrow(() -> new ChallengeException(ChallengeErrorCode.CHALLENGE_NOT_FOUND));
         ChallengeUser challengeUser = challengeUserRepository.findByUserAndChallenge(user, challenge)
-            .orElseThrow(() -> new ChallengeException(ChallengeErrorCode.NOT_MY_CHALLENGE));
+            .orElseThrow(() -> new ChallengeException(ChallengeErrorCode.NOT_PARTICIPATING));
 
         if (!challengeUser.isHost()) {
             throw new ChallengeException(ChallengeErrorCode.NOT_HOST);
@@ -125,7 +125,7 @@ public class ChallengeService {
         Challenge challenge = challengeRepository.findById(challengeId)
             .orElseThrow(() -> new ChallengeException(ChallengeErrorCode.CHALLENGE_NOT_FOUND));
         ChallengeUser challengeUser = challengeUserRepository.findByUserAndChallenge(user, challenge)
-            .orElseThrow(() -> new ChallengeException(ChallengeErrorCode.NOT_MY_CHALLENGE));
+            .orElseThrow(() -> new ChallengeException(ChallengeErrorCode.NOT_PARTICIPATING));
 
         if (!challengeUser.isHost()) {
             throw new ChallengeException(ChallengeErrorCode.NOT_HOST);

--- a/src/main/java/com/github/nenidan/ne_ne_challenge/domain/challenge/service/ChallengeUserService.java
+++ b/src/main/java/com/github/nenidan/ne_ne_challenge/domain/challenge/service/ChallengeUserService.java
@@ -1,18 +1,24 @@
 package com.github.nenidan.ne_ne_challenge.domain.challenge.service;
 
+import com.github.nenidan.ne_ne_challenge.domain.challenge.dto.response.ChallengeHistoryResponse;
 import com.github.nenidan.ne_ne_challenge.domain.challenge.entity.Challenge;
 import com.github.nenidan.ne_ne_challenge.domain.challenge.entity.ChallengeUser;
 import com.github.nenidan.ne_ne_challenge.domain.challenge.exception.ChallengeErrorCode;
 import com.github.nenidan.ne_ne_challenge.domain.challenge.exception.ChallengeException;
 import com.github.nenidan.ne_ne_challenge.domain.challenge.repository.ChallengeRepository;
 import com.github.nenidan.ne_ne_challenge.domain.challenge.repository.ChallengeUserRepository;
+import com.github.nenidan.ne_ne_challenge.domain.user.dto.response.UserResponse;
 import com.github.nenidan.ne_ne_challenge.domain.user.entity.User;
 import com.github.nenidan.ne_ne_challenge.domain.user.exception.UserErrorCode;
 import com.github.nenidan.ne_ne_challenge.domain.user.exception.UserException;
 import com.github.nenidan.ne_ne_challenge.domain.user.repository.UserRepository;
+import com.github.nenidan.ne_ne_challenge.global.dto.CursorResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
 
 @Service
 @Transactional(readOnly = true)
@@ -24,7 +30,7 @@ public class ChallengeUserService {
     private final ChallengeRepository challengeRepository;
 
     private final ChallengeUserRepository challengeUserRepository;
-    
+
     @Transactional
     public void joinChallenge(long userId, long challengeId, boolean isHost) {
         User user = userRepository.findById(userId).orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
@@ -34,7 +40,23 @@ public class ChallengeUserService {
         // Todo 사용자의 포인트 검증
         challenge.addParticipant(user);
         ChallengeUser challengeUser = new ChallengeUser(user, challenge, isHost);
-        
+
         challengeUserRepository.save(challengeUser);
+    }
+
+    public CursorResponse<UserResponse, Long> getChallengeParticipantList(Long id, Long cursor, int size) {
+        Challenge challenge = challengeRepository.findById(id).orElseThrow(() -> new ChallengeException(
+            ChallengeErrorCode.CHALLENGE_NOT_FOUND));
+
+        List<UserResponse> participantList = challengeUserRepository.getParticipantList(id,
+            cursor,
+            size
+        ).stream().map(UserResponse::from).toList();
+
+        boolean hasNext = participantList.size() > size;
+        List<UserResponse> content = hasNext ? participantList.subList(0, size) : participantList;
+        Long nextCursor = hasNext ? participantList.get(participantList.size() - 1).getId() : null;
+
+        return CursorResponse.of(content, nextCursor, hasNext);
     }
 }


### PR DESCRIPTION
## 변경 사항
- 챌린지 인증 기능 추가: 현재 기록물에 대한 별도 인증 과정 없음, 오늘 인증한 경우 추가 인증 불가능
- 챌린지 참가자 목록 조회 기능 추가
- 현재까지의 인증율 조회 기능 추가: 인증율 = (성공 일수 / 시작일부터 오늘까지 기간) * 100 을 소숫점 버림