### PR TITLE
feat(challenge): 통계값 제공 메소드 추가

### DIFF
--- a/src/main/java/com/github/nenidan/ne_ne_challenge/domain/challenge/dto/response/inner/InnerChallengeHistoryResponse.java
+++ b/src/main/java/com/github/nenidan/ne_ne_challenge/domain/challenge/dto/response/inner/InnerChallengeHistoryResponse.java
@@ -1,0 +1,50 @@
+package com.github.nenidan.ne_ne_challenge.domain.challenge.dto.response.inner;
+
+import com.github.nenidan.ne_ne_challenge.domain.challenge.entity.ChallengeLog;
+import com.github.nenidan.ne_ne_challenge.global.dto.InnerResponseBase;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class InnerChallengeHistoryResponse extends InnerResponseBase {
+
+    private Long id;
+
+    private Long userId;
+
+    private Long challengeId;
+
+    private String content;
+
+    private boolean isSuccess;
+
+    private InnerChallengeHistoryResponse(LocalDateTime createdAt,
+        LocalDateTime updatedAt,
+        LocalDateTime deletedAt,
+        Long id,
+        Long userId,
+        Long challengeId,
+        String content,
+        boolean isSuccess
+    ) {
+        super(createdAt, updatedAt, deletedAt);
+        this.id = id;
+        this.userId = userId;
+        this.challengeId = challengeId;
+        this.content = content;
+        this.isSuccess = isSuccess;
+    }
+
+    public static InnerChallengeHistoryResponse from(ChallengeLog challengeHistory) {
+        return new InnerChallengeHistoryResponse(challengeHistory.getCreatedAt(),
+            challengeHistory.getUpdatedAt(),
+            challengeHistory.getDeletedAt(),
+            challengeHistory.getId(),
+            challengeHistory.getUser().getId(),
+            challengeHistory.getChallenge().getId(),
+            challengeHistory.getContent(),
+            challengeHistory.isSuccess()
+        );
+    }
+}

--- a/src/main/java/com/github/nenidan/ne_ne_challenge/domain/challenge/dto/response/inner/InnerChallengeResponse.java
+++ b/src/main/java/com/github/nenidan/ne_ne_challenge/domain/challenge/dto/response/inner/InnerChallengeResponse.java
@@ -1,0 +1,83 @@
+package com.github.nenidan.ne_ne_challenge.domain.challenge.dto.response.inner;
+
+import com.github.nenidan.ne_ne_challenge.domain.challenge.entity.Challenge;
+import com.github.nenidan.ne_ne_challenge.domain.challenge.type.ChallengeCategory;
+import com.github.nenidan.ne_ne_challenge.domain.challenge.type.ChallengeStatus;
+import com.github.nenidan.ne_ne_challenge.global.dto.InnerResponseBase;
+import lombok.Getter;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Getter
+public class InnerChallengeResponse extends InnerResponseBase {
+
+    private Long id;
+
+    private String name;
+
+    private String description;
+
+    private ChallengeStatus status;
+
+    private int minParticipants;
+
+    private int maxParticipants;
+
+    private LocalDate dueAt;
+
+    private LocalDateTime startedAt;
+
+    private ChallengeCategory category;
+
+    private int participationFee;
+
+    private int totalFee;
+
+    public InnerChallengeResponse(Long id,
+        String name,
+        String description,
+        ChallengeStatus status,
+        int minParticipants,
+        int maxParticipants,
+        LocalDate dueAt,
+        LocalDateTime startedAt,
+        ChallengeCategory category,
+        int participationFee,
+        int totalFee,
+        LocalDateTime createdAt,
+        LocalDateTime updatedAt,
+        LocalDateTime deletedAt
+    ) {
+        super(createdAt, updatedAt, deletedAt);
+        this.id = id;
+        this.name = name;
+        this.description = description;
+        this.status = status;
+        this.minParticipants = minParticipants;
+        this.maxParticipants = maxParticipants;
+        this.dueAt = dueAt;
+        this.startedAt = startedAt;
+        this.category = category;
+        this.participationFee = participationFee;
+        this.totalFee = totalFee;
+    }
+
+    public static InnerChallengeResponse from(Challenge challenge) {
+        return new InnerChallengeResponse(challenge.getId(),
+            challenge.getName(),
+            challenge.getDescription(),
+            challenge.getStatus(),
+            challenge.getMinParticipants(),
+            challenge.getMaxParticipants(),
+            challenge.getDueAt(),
+            challenge.getStartedAt(),
+            challenge.getCategory(),
+            challenge.getParticipationFee(),
+            challenge.getTotalFee(),
+            challenge.getCreatedAt(),
+            challenge.getUpdatedAt(),
+            challenge.getDeletedAt()
+        );
+    }
+}

--- a/src/main/java/com/github/nenidan/ne_ne_challenge/domain/challenge/dto/response/inner/InnerChallengeUserResponse.java
+++ b/src/main/java/com/github/nenidan/ne_ne_challenge/domain/challenge/dto/response/inner/InnerChallengeUserResponse.java
@@ -1,0 +1,45 @@
+package com.github.nenidan.ne_ne_challenge.domain.challenge.dto.response.inner;
+
+import com.github.nenidan.ne_ne_challenge.domain.challenge.entity.ChallengeUser;
+import com.github.nenidan.ne_ne_challenge.global.dto.InnerResponseBase;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class InnerChallengeUserResponse extends InnerResponseBase {
+
+    private Long id;
+
+    private Long challengeId;
+
+    private Long userId;
+
+    private boolean isHost;
+
+    public InnerChallengeUserResponse(LocalDateTime createdAt,
+        LocalDateTime updatedAt,
+        LocalDateTime deletedAt,
+        Long id,
+        Long challengeId,
+        Long userId,
+        boolean isHost
+    ) {
+        super(createdAt, updatedAt, deletedAt);
+        this.id = id;
+        this.challengeId = challengeId;
+        this.userId = userId;
+        this.isHost = isHost;
+    }
+
+    public static InnerChallengeUserResponse from(ChallengeUser challengeUser) {
+        return new InnerChallengeUserResponse(challengeUser.getCreatedAt(),
+            challengeUser.getUpdatedAt(),
+            challengeUser.getDeletedAt(),
+            challengeUser.getId(),
+            challengeUser.getChallenge().getId(),
+            challengeUser.getUser().getId(),
+            challengeUser.isHost()
+        );
+    }
+}

--- a/src/main/java/com/github/nenidan/ne_ne_challenge/domain/challenge/service/ChallengeService.java
+++ b/src/main/java/com/github/nenidan/ne_ne_challenge/domain/challenge/service/ChallengeService.java
@@ -4,6 +4,8 @@ import com.github.nenidan.ne_ne_challenge.domain.challenge.dto.request.Challenge
 import com.github.nenidan.ne_ne_challenge.domain.challenge.dto.request.CreateChallengeRequest;
 import com.github.nenidan.ne_ne_challenge.domain.challenge.dto.request.UpdateChallengeRequest;
 import com.github.nenidan.ne_ne_challenge.domain.challenge.dto.response.ChallengeResponse;
+import com.github.nenidan.ne_ne_challenge.domain.challenge.dto.response.inner.InnerChallengeHistoryResponse;
+import com.github.nenidan.ne_ne_challenge.domain.challenge.dto.response.inner.InnerChallengeResponse;
 import com.github.nenidan.ne_ne_challenge.domain.challenge.entity.Challenge;
 import com.github.nenidan.ne_ne_challenge.domain.challenge.entity.ChallengeUser;
 import com.github.nenidan.ne_ne_challenge.domain.challenge.exception.ChallengeErrorCode;
@@ -134,5 +136,12 @@ public class ChallengeService {
 
         challenge.delete();
         return null;
+    }
+
+    // 초기 통계값 개발을 위한 전체 데이터 반환 메소드
+    public List<InnerChallengeResponse> getAllChallengeList() {
+        return challengeRepository.findAll().stream() // 메모리 부족 주의
+            .map(InnerChallengeResponse::from)
+            .toList();
     }
 }

--- a/src/main/java/com/github/nenidan/ne_ne_challenge/domain/challenge/service/ChallengeUserService.java
+++ b/src/main/java/com/github/nenidan/ne_ne_challenge/domain/challenge/service/ChallengeUserService.java
@@ -1,5 +1,7 @@
 package com.github.nenidan.ne_ne_challenge.domain.challenge.service;
 
+import com.github.nenidan.ne_ne_challenge.domain.challenge.dto.response.inner.InnerChallengeHistoryResponse;
+import com.github.nenidan.ne_ne_challenge.domain.challenge.dto.response.inner.InnerChallengeUserResponse;
 import com.github.nenidan.ne_ne_challenge.domain.challenge.entity.Challenge;
 import com.github.nenidan.ne_ne_challenge.domain.challenge.entity.ChallengeUser;
 import com.github.nenidan.ne_ne_challenge.domain.challenge.exception.ChallengeErrorCode;
@@ -13,6 +15,8 @@ import com.github.nenidan.ne_ne_challenge.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Service
 @Transactional(readOnly = true)
@@ -36,5 +40,12 @@ public class ChallengeUserService {
         ChallengeUser challengeUser = new ChallengeUser(user, challenge, isHost);
         
         challengeUserRepository.save(challengeUser);
+    }
+
+    // 초기 통계값 개발을 위한 전체 데이터 반환 메소드
+    public List<InnerChallengeUserResponse> getAllChallengeUserList() {
+        return challengeUserRepository.findAll().stream() // 메모리 부족 주의
+            .map(InnerChallengeUserResponse::from)
+            .toList();
     }
 }

--- a/src/main/java/com/github/nenidan/ne_ne_challenge/global/dto/InnerResponseBase.java
+++ b/src/main/java/com/github/nenidan/ne_ne_challenge/global/dto/InnerResponseBase.java
@@ -1,0 +1,22 @@
+package com.github.nenidan.ne_ne_challenge.global.dto;
+
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+// 각 응답 객체에서 @AllArgsConstructor 대신 생성자 직접 생성 필요
+@Getter
+public abstract class InnerResponseBase {
+
+    protected LocalDateTime createdAt;
+
+    protected LocalDateTime updatedAt;
+
+    protected LocalDateTime deletedAt;
+
+    public InnerResponseBase(LocalDateTime createdAt, LocalDateTime updatedAt, LocalDateTime deletedAt) {
+        this.createdAt = createdAt;
+        this.updatedAt = updatedAt;
+        this.deletedAt = deletedAt;
+    }
+}


### PR DESCRIPTION
## 변경 사항
- `ChallengeService#getAllChallengeList`를 통해 엔티티 모든 정보를 가진 응답 DTO를 받아올 수 있음
- `ChallengeUserService#getAllChallengeUserList`도 유사하게 동작

## 주의 사항
- dev에 머지 예정인 브랜치(feat/challenge/others)에서 클래스 명을 `ChallengeLog `→ `ChallengeHistory`로 수정했기에 `InnerChallengeHistoryResponse`로 작성
- `ChallengeHistoryRepository`가 feat/challenge/others에 있어 해당 응답값을 받는 메소드는 아직 미구현