### PR TITLE
fix(challenge): ChallengeApplicationService#deleteChallenge 버그 수정

### DIFF
--- a/src/main/java/com/github/nenidan/ne_ne_challenge/domain/challenge/application/ChallengeApplicationService.java
+++ b/src/main/java/com/github/nenidan/ne_ne_challenge/domain/challenge/application/ChallengeApplicationService.java
@@ -66,7 +66,7 @@ public class ChallengeApplicationService {
         userClient.getUserById(userId);
         challengeFacade.checkChallengeHost(userId, challengeId);
 
-        List<Long> userIdList = challengeFacade.getParticipantList(challengeId).stream().map(Participant::getId).toList();
+        List<Long> userIdList = challengeFacade.getParticipantList(challengeId).stream().map(Participant::getUserId).toList();
         int amount = challengeFacade.getChallengeParticipationFee(challengeId);
         pointClient.refundPoints(userIdList, amount);
 


### PR DESCRIPTION
## 변경 사항
`ChallengeApplicationService#deleteChallenge` 에서 `userId`가 아닌 `Participant`의 대리키를 반납하도록 되어 있어 취소 시 포인트가 환급되지 않는 버그 수정