### PR TITLE
챌린지 부문 통계 조회를 위한 API 추가

### DIFF
--- a/src/main/java/com/github/nenidan/ne_ne_challenge/domain/challenge/application/ChallengeStatisticsService.java
+++ b/src/main/java/com/github/nenidan/ne_ne_challenge/domain/challenge/application/ChallengeStatisticsService.java
@@ -1,0 +1,39 @@
+package com.github.nenidan.ne_ne_challenge.domain.challenge.application;
+
+import com.github.nenidan.ne_ne_challenge.domain.challenge.application.dto.response.ChallengeResponse;
+import com.github.nenidan.ne_ne_challenge.domain.challenge.application.dto.response.inner.InnerChallengeResponse;
+import com.github.nenidan.ne_ne_challenge.domain.challenge.application.dto.response.inner.InnerHistoryResponse;
+import com.github.nenidan.ne_ne_challenge.domain.challenge.application.dto.response.inner.InnerParticipantResponse;
+import com.github.nenidan.ne_ne_challenge.domain.challenge.application.mapper.InnerChallengeMapper;
+import com.github.nenidan.ne_ne_challenge.domain.challenge.domain.repository.ChallengeRepository;
+import com.github.nenidan.ne_ne_challenge.domain.challenge.domain.repository.HistoryReposiroty;
+import com.github.nenidan.ne_ne_challenge.domain.challenge.domain.repository.ParticipantRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+/**
+ * 내부 조회용으로 ResponseDto를 반환해주는 서비스
+ */
+@Service
+@RequiredArgsConstructor
+public class ChallengeStatisticsService {
+
+    private final ChallengeRepository challengeRepository;
+    private final ParticipantRepository participantRepository;
+    private final HistoryReposiroty historyReposiroty;
+    private final InnerChallengeMapper innerChallengeMapper = InnerChallengeMapper.INSTANCE;
+
+    public List<InnerChallengeResponse> getAllChallenge() {
+        return challengeRepository.findAll().stream().map(innerChallengeMapper::toResponse).toList();
+    }
+
+    public List<InnerParticipantResponse> getAllParticipant() {
+        return participantRepository.findAll().stream().map(innerChallengeMapper::toResponse).toList();
+    }
+
+    public List<InnerHistoryResponse> getAllHistory() {
+        return historyReposiroty.findAll().stream().map(innerChallengeMapper::toResponse).toList();
+    }
+}

--- a/src/main/java/com/github/nenidan/ne_ne_challenge/domain/challenge/application/dto/response/inner/InnerChallengeResponse.java
+++ b/src/main/java/com/github/nenidan/ne_ne_challenge/domain/challenge/application/dto/response/inner/InnerChallengeResponse.java
@@ -1,0 +1,41 @@
+package com.github.nenidan.ne_ne_challenge.domain.challenge.application.dto.response.inner;
+
+import com.github.nenidan.ne_ne_challenge.domain.challenge.domain.model.type.ChallengeCategory;
+import com.github.nenidan.ne_ne_challenge.domain.challenge.domain.model.type.ChallengeStatus;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+public class InnerChallengeResponse {
+    private Long id;
+
+    private String name;
+
+    private String description;
+
+    private ChallengeStatus status;
+
+    private ChallengeCategory category;
+
+    private int minParticipants;
+
+    private int maxParticipants;
+
+    private int participationFee;
+
+    private int totalFee;
+
+    private LocalDate startAt;
+
+    private LocalDate dueAt;
+
+    private LocalDateTime createdAt;
+
+    private LocalDateTime updatedAt;
+
+    private LocalDateTime deletedAt;
+}

--- a/src/main/java/com/github/nenidan/ne_ne_challenge/domain/challenge/application/dto/response/inner/InnerHistoryResponse.java
+++ b/src/main/java/com/github/nenidan/ne_ne_challenge/domain/challenge/application/dto/response/inner/InnerHistoryResponse.java
@@ -1,0 +1,27 @@
+package com.github.nenidan.ne_ne_challenge.domain.challenge.application.dto.response.inner;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+public class InnerHistoryResponse {
+
+    private Long id;
+
+    private Long userId;
+
+    private Long challengeId;
+
+    private String content;
+
+    private boolean isSuccess;
+
+    private LocalDateTime createdAt;
+
+    private LocalDateTime updatedAt;
+
+    private LocalDateTime deletedAt;
+}

--- a/src/main/java/com/github/nenidan/ne_ne_challenge/domain/challenge/application/dto/response/inner/InnerParticipantResponse.java
+++ b/src/main/java/com/github/nenidan/ne_ne_challenge/domain/challenge/application/dto/response/inner/InnerParticipantResponse.java
@@ -1,0 +1,24 @@
+package com.github.nenidan.ne_ne_challenge.domain.challenge.application.dto.response.inner;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+public class InnerParticipantResponse {
+    private Long id;
+
+    private Long userId;
+
+    private Long challengeId;
+
+    private boolean isHost;
+
+    private LocalDateTime createdAt;
+
+    private LocalDateTime updatedAt;
+
+    private LocalDateTime deletedAt;
+}

--- a/src/main/java/com/github/nenidan/ne_ne_challenge/domain/challenge/application/mapper/InnerChallengeMapper.java
+++ b/src/main/java/com/github/nenidan/ne_ne_challenge/domain/challenge/application/mapper/InnerChallengeMapper.java
@@ -1,0 +1,24 @@
+package com.github.nenidan.ne_ne_challenge.domain.challenge.application.mapper;
+
+import com.github.nenidan.ne_ne_challenge.domain.challenge.application.dto.response.inner.InnerChallengeResponse;
+import com.github.nenidan.ne_ne_challenge.domain.challenge.application.dto.response.inner.InnerHistoryResponse;
+import com.github.nenidan.ne_ne_challenge.domain.challenge.application.dto.response.inner.InnerParticipantResponse;
+import com.github.nenidan.ne_ne_challenge.domain.challenge.domain.model.entity.Challenge;
+import com.github.nenidan.ne_ne_challenge.domain.challenge.domain.model.entity.History;
+import com.github.nenidan.ne_ne_challenge.domain.challenge.domain.model.entity.Participant;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.factory.Mappers;
+
+@Mapper
+public interface InnerChallengeMapper {
+    InnerChallengeMapper INSTANCE = Mappers.getMapper(InnerChallengeMapper.class);
+
+    InnerChallengeResponse toResponse(Challenge challenge);
+
+    @Mapping(source = "challenge.id", target = "challengeId")
+    InnerParticipantResponse toResponse(Participant participant);
+
+    @Mapping(source = "challenge.id", target = "challengeId")
+    InnerHistoryResponse toResponse(History history);
+}

--- a/src/main/java/com/github/nenidan/ne_ne_challenge/domain/challenge/domain/repository/ChallengeRepository.java
+++ b/src/main/java/com/github/nenidan/ne_ne_challenge/domain/challenge/domain/repository/ChallengeRepository.java
@@ -25,4 +25,6 @@ public interface ChallengeRepository {
         LocalDateTime cursor,
         int limit
     );
+
+    List<Challenge> findAll();
 }

--- a/src/main/java/com/github/nenidan/ne_ne_challenge/domain/challenge/domain/repository/HistoryReposiroty.java
+++ b/src/main/java/com/github/nenidan/ne_ne_challenge/domain/challenge/domain/repository/HistoryReposiroty.java
@@ -16,4 +16,6 @@ public interface HistoryReposiroty {
     List<History> getHistoryList(Long challengeId, Long userId, LocalDateTime cursor, int limit);
 
     int countOfSuccess(Long challengeId, Long userId);
+
+    List<History> findAll();
 }

--- a/src/main/java/com/github/nenidan/ne_ne_challenge/domain/challenge/domain/repository/ParticipantRepository.java
+++ b/src/main/java/com/github/nenidan/ne_ne_challenge/domain/challenge/domain/repository/ParticipantRepository.java
@@ -15,4 +15,6 @@ public interface ParticipantRepository {
     List<Participant> findbyChallengeId(Long challengeId);
 
     int getParticipantCount(Long challengeId);
+
+    List<Participant> findAll();
 }

--- a/src/main/java/com/github/nenidan/ne_ne_challenge/domain/challenge/infrastructure/repository/ChallengeRepositoryImpl.java
+++ b/src/main/java/com/github/nenidan/ne_ne_challenge/domain/challenge/infrastructure/repository/ChallengeRepositoryImpl.java
@@ -42,4 +42,9 @@ public class ChallengeRepositoryImpl implements ChallengeRepository {
     ) {
         return jpaChallengeRepository.getChallengeList(userId, name, status, dueAt, category, maxParticipationFee, cursor, limit);
     }
+
+    @Override
+    public List<Challenge> findAll() {
+        return jpaChallengeRepository.findAll();
+    }
 }

--- a/src/main/java/com/github/nenidan/ne_ne_challenge/domain/challenge/infrastructure/repository/HistoryRepositoryImpl.java
+++ b/src/main/java/com/github/nenidan/ne_ne_challenge/domain/challenge/infrastructure/repository/HistoryRepositoryImpl.java
@@ -41,4 +41,9 @@ public class HistoryRepositoryImpl implements HistoryReposiroty {
         return jpaHistoryRepository.countByChallenge_IdAndUserIdAndIsSuccessTrue(challengeId, userId);
     }
 
+    @Override
+    public List<History> findAll() {
+        return jpaHistoryRepository.findAll();
+    }
+
 }

--- a/src/main/java/com/github/nenidan/ne_ne_challenge/domain/challenge/infrastructure/repository/ParticipantRepositoryImpl.java
+++ b/src/main/java/com/github/nenidan/ne_ne_challenge/domain/challenge/infrastructure/repository/ParticipantRepositoryImpl.java
@@ -40,4 +40,9 @@ public class ParticipantRepositoryImpl implements ParticipantRepository {
     public int getParticipantCount(Long challengeId) {
         return jpaParticipantRepository.countByChallenge_Id(challengeId);
     }
+
+    @Override
+    public List<Participant> findAll() {
+        return jpaParticipantRepository.findAll();
+    }
 }

--- a/src/main/java/com/github/nenidan/ne_ne_challenge/domain/challenge/presentation/controller/ChallengeStatisticsController.java
+++ b/src/main/java/com/github/nenidan/ne_ne_challenge/domain/challenge/presentation/controller/ChallengeStatisticsController.java
@@ -1,0 +1,50 @@
+package com.github.nenidan.ne_ne_challenge.domain.challenge.presentation.controller;
+
+import com.github.nenidan.ne_ne_challenge.domain.challenge.application.ChallengeStatisticsService;
+import com.github.nenidan.ne_ne_challenge.domain.challenge.application.dto.response.inner.InnerChallengeResponse;
+import com.github.nenidan.ne_ne_challenge.domain.challenge.application.dto.response.inner.InnerHistoryResponse;
+import com.github.nenidan.ne_ne_challenge.domain.challenge.application.dto.response.inner.InnerParticipantResponse;
+import com.github.nenidan.ne_ne_challenge.global.dto.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api")
+public class ChallengeStatisticsController {
+
+    private final ChallengeStatisticsService challengeStatisticsService;
+
+    @GetMapping("/statistics/challenges")
+    public ResponseEntity<ApiResponse<List<InnerChallengeResponse>>> getAllChallenges() {
+        return ApiResponse.success(
+            HttpStatus.OK,
+            "전체 챌린지 목록",
+            challengeStatisticsService.getAllChallenge()
+        );
+    }
+
+    @GetMapping("/statistics/participants")
+    public ResponseEntity<ApiResponse<List<InnerParticipantResponse>>> getAllParticipants() {
+        return ApiResponse.success(
+            HttpStatus.OK,
+            "전체 참가자 목록",
+            challengeStatisticsService.getAllParticipant()
+        );
+    }
+
+    @GetMapping("/statistics/history")
+    public ResponseEntity<ApiResponse<List<InnerHistoryResponse>>> getAllHistory() {
+        return ApiResponse.success(
+            HttpStatus.OK,
+            "전체 인증 기록 목록",
+            challengeStatisticsService.getAllHistory()
+        );
+    }
+}


### PR DESCRIPTION
## 변경 사항
- 전체 `Challenge`, `Participant`, `History`를 `List`로 조회하는 API 추가 (/api/statistics/<challenges | participants | history>)
 - 이를 지원하기 위해 각 리포지토리 인터페이스에 `findAll` 추가

## 주의 사항
- 임시용으로 생각하여 Spring Security 인가 신경쓰지 않음
- `BaseEntity`를 포함한 전체 엔티티 데이터 반환