### PR TITLE
챌린지 버그 수정 및 yml 옵션 수정

### DIFF
--- a/src/main/java/com/github/nenidan/ne_ne_challenge/domain/challenge/domain/model/entity/Challenge.java
+++ b/src/main/java/com/github/nenidan/ne_ne_challenge/domain/challenge/domain/model/entity/Challenge.java
@@ -236,6 +236,10 @@ public class Challenge extends BaseEntity {
             .findFirst()
             .orElseThrow(() -> new ChallengeException(NOT_PARTICIPATING));
 
+        if(status == WAITING) {
+            totalFee -= participationFee;
+        }
+
         participants.remove(participant);
         currentParticipantCount--;
     }

--- a/src/main/java/com/github/nenidan/ne_ne_challenge/domain/challenge/domain/model/entity/Challenge.java
+++ b/src/main/java/com/github/nenidan/ne_ne_challenge/domain/challenge/domain/model/entity/Challenge.java
@@ -154,6 +154,10 @@ public class Challenge extends BaseEntity {
         verifyHost(loginUserId);
         verifyWaiting();
 
+        if(currentParticipantCount != 1) {
+            throw new ChallengeException(NOT_MODIFIABLE);
+        }
+
         String newName = info.getName();
         if(newName != null && !newName.isEmpty()) {
             this.name = newName;

--- a/src/main/java/com/github/nenidan/ne_ne_challenge/domain/challenge/presentation/mapper/ChallengeResponseMapper.java
+++ b/src/main/java/com/github/nenidan/ne_ne_challenge/domain/challenge/presentation/mapper/ChallengeResponseMapper.java
@@ -21,7 +21,6 @@ public interface ChallengeResponseMapper {
 
     ChallengeResponse fromDto(ChallengeDto dto);
 
-    @Mapping(source = "success", target = "isSuccess")
     ChallengeHistoryResponse fromDto(ChallengeHistoryDto dto);
     ChallengeSuccessRateResponse fromDto(ChallengeSuccessRateDto dto);
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -116,6 +116,7 @@ spring:
     properties:
       hibernate:
         dialect: org.hibernate.dialect.MySQLDialect
+      ddl-auto: none
 
   firebase:
     config:


### PR DESCRIPTION
## 변경 사항
- WAITING에서 챌린지 퇴장 시 totalFee 감소하지 않는 버그 수정
- prod 프로필에서 ddl-auto 값은 none
- 방장 이외 참가자가 있으면 챌린지 정보를 변경할 수 없도록 수정
- ChallengeResponse의 HistoryResponse 변환에서 `@Mapping` 어노테이션 제거